### PR TITLE
Http1 header order

### DIFF
--- a/example_client_test.go
+++ b/example_client_test.go
@@ -1,6 +1,7 @@
 package http_test
 
 import (
+	"bytes"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -183,6 +184,60 @@ func TestWithCert(t *testing.T) {
 
 	if resp.StatusCode != 200 {
 		t.Errorf("Expected status code 200, got %v", resp.StatusCode)
+	}
+}
+
+func TestHTTP1HeaderOrder(t *testing.T) {
+	req, err := http.NewRequest("GET", "https://prod.jdgroupmesh.cloud/stores/size/products/16069871?channel=android-app-phone&expand=variations,informationBlocks,customisations", nil)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	req.Header = http.Header{
+		"X-NewRelic-ID":         {"12345"},
+		"x-api-key":             {"ABCDE12345"},
+		"MESH-Commerce-Channel": {"android-app-phone"},
+		"mesh-version":          {"cart=4"},
+		"User-Agent":            {"size/3.1.0.8355 (android-app-phone; Android 10; Build/CPH2185_11_A.28)"},
+		"X-Request-Auth":        {"hawkHeader"},
+		"X-acf-sensor-data":     {"3456"},
+		"Content-Type":          {"application/json; charset=UTF-8"},
+		"Accept":                {"application/json"},
+		"Transfer-Encoding":     {"chunked"},
+		"Host":                  {"prod.jdgroupmesh.cloud"},
+		"Connection":            {"Keep-Alive"},
+		"Accept-Encoding":       {"gzip"},
+		http.HeaderOrderKey: {
+			"X-NewRelic-ID",
+			"x-api-key",
+			"MESH-Commerce-Channel",
+			"mesh-version",
+			"User-Agent",
+			"X-Request-Auth",
+			"X-acf-sensor-data",
+			"Transfer-Encoding",
+			"Content-Type",
+			"Accept",
+			"Host",
+			"Connection",
+			"Accept-Encoding",
+		},
+		http.PHeaderOrderKey: {
+			":method",
+			":path",
+			":authority",
+			":scheme",
+		},
+	}
+
+	var b []byte
+	buf := bytes.NewBuffer(b)
+	err = req.Write(buf)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	expected := "GET /stores/size/products/16069871?channel=android-app-phone&expand=variations,informationBlocks,customisations HTTP/1.1\r\nX-NewRelic-ID: 12345\r\nx-api-key: ABCDE12345\r\nMESH-Commerce-Channel: android-app-phone\r\nmesh-version: cart=4\r\nUser-Agent: size/3.1.0.8355 (android-app-phone; Android 10; Build/CPH2185_11_A.28)\r\nX-Request-Auth: hawkHeader\r\nX-acf-sensor-data: 3456\r\nTransfer-Encoding: chunked\r\nContent-Type: application/json; charset=UTF-8\r\nAccept: application/json\r\nHost: prod.jdgroupmesh.cloud\r\nConnection: Keep-Alive\r\nAccept-Encoding: gzip\r\n\r\n"
+	if expected != buf.String() {
+		t.Fatalf("got: %swant: %s", buf.String(), expected)
 	}
 }
 

--- a/header.go
+++ b/header.go
@@ -178,8 +178,8 @@ func (s *headerSorter) Less(i, j int) bool {
 	if s.order == nil {
 		return s.kvs[i].Key < s.kvs[j].Key
 	}
-	idxi, iok := s.order[strings.ToLower(s.kvs[i].Key)]
-	idxj, jok := s.order[strings.ToLower(s.kvs[j].Key)]
+	idxi, iok := s.order[s.kvs[i].Key]
+	idxj, jok := s.order[s.kvs[j].Key]
 	if !iok && !jok {
 		return s.kvs[i].Key < s.kvs[j].Key
 	} else if !iok && jok {
@@ -233,6 +233,7 @@ func (h Header) SortedKeyValuesBy(order map[string]int, exclude map[string]bool)
 	hs.kvs = kvs
 	hs.order = order
 	sort.Sort(hs)
+
 	return kvs, hs
 }
 

--- a/header_test.go
+++ b/header_test.go
@@ -91,17 +91,56 @@ var headerWriteTests = []struct {
 			"k7: 7a\r\nk7: 7b\r\nk8: 8a\r\nk8: 8b\r\nk9: 9a\r\nk9: 9b\r\n",
 	},
 	// Test sorting headers by the special Header-Order header
+	//{
+	//	Header{
+	//		"a":            {"2"},
+	//		"b":            {"3"},
+	//		"e":            {"1"},
+	//		"c":            {"5"},
+	//		"d":            {"4"},
+	//		HeaderOrderKey: {"e", "a", "b", "d", "c"},
+	//	},
+	//	nil,
+	//	"e: 1\r\na: 2\r\nb: 3\r\nd: 4\r\nc: 5\r\n",
+	//},
+	// Make sure that http 1.1 capitla letters are also sorted properly
 	{
 		Header{
-			"a":            {"2"},
-			"b":            {"3"},
-			"e":            {"1"},
-			"c":            {"5"},
-			"d":            {"4"},
-			HeaderOrderKey: {"e", "a", "b", "d", "c"},
+			"X-NewRelic-ID":         {"12345"},
+			"x-api-key":             {"ABCDEFGHIJKLMNOPQRSTUVWXYZ"},
+			"MESH-Commerce-Channel": {"android-app-phone"},
+			"mesh-version":          {"cart=4"},
+			"User-Agent":            {"size/3.1.0.8355 (android-app-phone; Android 10; Build/CPH2185_11_A.28)"},
+			"X-Request-Auth":        {"hawkHeader"},
+			"X-acf-sensor-data":     {"3456"},
+			"Content-Type":          {"application/json; charset=UTF-8"},
+			"Accept":                {"application/json"},
+			"Transfer-Encoding":     {"chunked"},
+			"Host":                  {"prod.jdgroupmesh.cloud"},
+			"Connection":            {"Keep-Alive"},
+			"Accept-Encoding":       {"gzip"},
+			HeaderOrderKey: {
+				"X-NewRelic-ID",
+				"x-api-key",
+				"MESH-Commerce-Channel",
+				"mesh-version",
+				"User-Agent",
+				"X-Request-Auth",
+				"X-acf-sensor-data",
+				"Content-Type",
+				"Accept",
+				"Transfer-Encoding",
+				"Host",
+				"Connection",
+				"Accept-Encoding",
+			},
 		},
 		nil,
-		"e: 1\r\na: 2\r\nb: 3\r\nd: 4\r\nc: 5\r\n",
+		"X-NewRelic-ID: 12345\r\nx-api-key: ABCDEFGHIJKLMNOPQRSTUVWXYZ\r\nMESH-Commerce-Channel: android-app-phone\r\n" +
+			"mesh-version: cart=4\r\nUser-Agent: size/3.1.0.8355 (android-app-phone; Android 10; Build/CPH2185_11_A.28)\r\n" +
+			"X-Request-Auth: hawkHeader\r\nX-acf-sensor-data: 3456\r\nContent-Type: application/json; charset=UTF-8\r\n" +
+			"Accept: application/json\r\nTransfer-Encoding: chunked\r\nHost: prod.jdgroupmesh.cloud\r\nConnection: Keep-Alive\r\n" +
+			"Accept-Encoding: gzip\r\n",
 	},
 }
 

--- a/http2/fhttp_test.go
+++ b/http2/fhttp_test.go
@@ -133,7 +133,7 @@ func TestRoundTrip(t *testing.T) {
 
 // Tests if content-length header is present in request headers during POST
 func TestContentLength(t *testing.T) {
-	ts := httptest.NewUnstartedServer(http.HandlerFunc(func (w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if hdr, ok := r.Header["Content-Length"]; ok {
 			if len(hdr) != 1 {
 				t.Fatalf("Got %v content-length headers, should only be 1", len(hdr))
@@ -168,7 +168,7 @@ func TestContentLength(t *testing.T) {
 
 // TestClient_Cookies tests whether set cookies are being sent
 func TestClient_SendsCookies(t *testing.T) {
-	ts := httptest.NewUnstartedServer(http.HandlerFunc(func (w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		cookie, err := r.Cookie("cookie")
 		if err != nil {
 			t.Fatalf(err.Error())
@@ -216,7 +216,7 @@ func TestClient_Load(t *testing.T) {
 	c := http.Client{
 		Transport: &http.Transport{
 			ForceAttemptHTTP2: true,
-			Proxy: http.ProxyURL(u),
+			Proxy:             http.ProxyURL(u),
 			TLSClientConfig: &tls.Config{
 				RootCAs: pool,
 			},
@@ -226,7 +226,7 @@ func TestClient_Load(t *testing.T) {
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
-	for i:=0;i<10;i++ {
+	for i := 0; i < 10; i++ {
 		resp, err := c.Do(req)
 		if err != nil {
 			t.Fatalf(err.Error())
@@ -248,7 +248,7 @@ func TestGClient_Load(t *testing.T) {
 	c := ghttp.Client{
 		Transport: &ghttp.Transport{
 			ForceAttemptHTTP2: true,
-			Proxy: ghttp.ProxyURL(u),
+			Proxy:             ghttp.ProxyURL(u),
 			TLSClientConfig: &tls.Config{
 				RootCAs: pool,
 			},
@@ -258,7 +258,7 @@ func TestGClient_Load(t *testing.T) {
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
-	for i:=0;i<10;i++ {
+	for i := 0; i < 10; i++ {
 		err := do(&c, req)
 		if err != nil {
 			t.Fatalf(err.Error())

--- a/http2/transport.go
+++ b/http2/transport.go
@@ -1669,7 +1669,7 @@ func (cc *ClientConn) encodeHeaders(req *http.Request, addGzipHeader bool, trail
 		}
 
 		for _, kv := range kvs {
-			if strings.EqualFold(kv.Key, "host")  {
+			if strings.EqualFold(kv.Key, "host") {
 				// Host is :authority, already sent.
 				continue
 			} else if strings.EqualFold(kv.Key, "connection") || strings.EqualFold(kv.Key, "proxy-connection") ||


### PR DESCRIPTION
Fixed http1 header order, where sorting always used lowercase and therefore didn't work with http 1.1