### PR TITLE
fix import error

### DIFF
--- a/http2/http2.go
+++ b/http2/http2.go
@@ -14,7 +14,7 @@
 //
 // See https://http2.golang.org/ for a test server running this code.
 //
-package http2 // import "golang.org/x/net/http2"
+package http2 // import "github.com/useflyent/fhttp/http2"
 
 import (
 	"bufio"


### PR DESCRIPTION
importing the http2 module like so
`import ( http2 "github.com/useflyent/fhttp/http2" )`

 results in `code in directory {path}/useflyent/fhttp/http2 expects import "golang.org/x/net/http2"`. This PR should fix that 